### PR TITLE
Match HashWithIndifferentAccess#default and Hash#default

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -64,12 +64,18 @@ module ActiveSupport
       end
     end
 
-    def default(key = nil)
-      if key.is_a?(Symbol) && include?(key = key.to_s)
-        self[key]
-      else
-        super
-      end
+    def default(*args)
+      key = args.first
+      args[0] = key.to_s if key.is_a?(Symbol)
+      super(*args)
+    end
+
+    def [](key)
+      super(convert_key(key))
+    end
+
+    def fetch(key, *args)
+      super(convert_key(key), *args)
     end
 
     def self.new_from_hash_copying_default(hash)

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1523,9 +1523,9 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal 3, hash_wia[:new_key]
   end
 
-  def test_should_use_default_proc_if_no_key_is_supplied
+  def test_should_return_nil_if_no_key_is_supplied
     hash_wia = HashWithIndifferentAccess.new { 1 +  2 }
-    assert_equal 3, hash_wia.default
+    assert_equal nil, hash_wia.default
   end
 
   def test_should_use_default_value_for_unknown_key


### PR DESCRIPTION
The behaviour for Ruby's `Hash` is as follows

``` ruby
default_value = Hash.new(:default)
default_value[:foo] = :bar
default_value.default # => :default
default_value.default(:foo) # => :default
default_value # => {:foo=>:bar}

default_proc = Hash.new { |h, k| h[k] = [] }
default_proc[:foo] = :bar
default_proc.default # => nil
default_proc.default(:foo) # => []
default_proc # => {:foo=>[]}
```

whereas `HashWithIndifferentAccess`

``` ruby
default_value = ActiveSupport::HashWithIndifferentAccess.new(:default)
default_value[:foo] = :bar
default_value.default # => :default
default_value.default(:foo) # => :bar
default_value # => {"foo"=>:bar}

default_proc = ActiveSupport::HashWithIndifferentAccess.new { |h, k| h[k] = [] }
default_proc[:foo] = :bar
default_proc.default # => []
default_proc.default(:foo) # => :bar
default_proc # => {"foo"=>:bar, nil=>[]}
```
